### PR TITLE
Fixed [bug]: target function has args and kwargs as param

### DIFF
--- a/async_files/fileio.py
+++ b/async_files/fileio.py
@@ -30,7 +30,8 @@ class FileIO(metaclass=FileIOMeta):
         return await self.open()
 
     async def open(self):
-        file = await self.__class__.OPEN(*self.bound_args.args, **self.bound_args.kwargs)
+        file = await self.__class__.OPEN(*self.bound_args.args,
+                                         **self.bound_args.kwargs)
         self._file = self.__class__.FILEOBJ(file,
                                             self.bound_args.arguments["mode"])
         return self._file

--- a/async_files/fileio.py
+++ b/async_files/fileio.py
@@ -30,7 +30,7 @@ class FileIO(metaclass=FileIOMeta):
         return await self.open()
 
     async def open(self):
-        file = await self.__class__.OPEN(**self.bound_args.arguments)
+        file = await self.__class__.OPEN(*self.bound_args.args, **self.bound_args.kwargs)
         self._file = self.__class__.FILEOBJ(file,
                                             self.bound_args.arguments["mode"])
         return self._file

--- a/examples/tarfile_example.py
+++ b/examples/tarfile_example.py
@@ -35,7 +35,8 @@ async def main():
     # create a test directory
     tempdir = tempfile.mkdtemp()
     testdir = os.path.join(tempdir, "test")
-    os.makedirs(testdir) if not os.path.isdir(testdir) else None
+    if not os.path.isdir(testdir):
+        os.makedirs(testdir)
     with open(os.path.join(testdir, "test.txt"), "w") as f:
         f.write("Hello World!")
 

--- a/examples/tarfile_example.py
+++ b/examples/tarfile_example.py
@@ -1,0 +1,48 @@
+import os
+import tarfile
+import tempfile
+
+from async_files import FileIO
+from async_files.fileobj import DEFAULT_CONFIG, FileObj
+from .utils import run_coroutine, ChangeDirContext
+
+TARBALL_CONFIG = DEFAULT_CONFIG
+TARBALL_CONFIG["strings_async_attrs"].extend(["add", "extract", "extractall"])
+
+
+class TarballFileObj(FileObj):
+    CONFIG = TARBALL_CONFIG
+    add: callable
+    extract: callable
+    extractall: callable
+
+
+class async_open(FileIO):
+    OPEN = tarfile.TarFile.open
+    FILEOBJ = TarballFileObj
+
+
+async def make_tarfile_from_dir(output_filename, source_dir):
+    if not output_filename.endswith('.gz'):
+        output_filename += '.tar.gz'
+    async with async_open(output_filename, "w:gz") as tar:
+        await tar.add(source_dir, arcname=".")
+
+    return output_filename
+
+
+async def main():
+    # create a test directory
+    tempdir = tempfile.mkdtemp()
+    testdir = os.path.join(tempdir, "test")
+    os.makedirs(testdir) if not os.path.isdir(testdir) else None
+    with open(os.path.join(testdir, "test.txt"), "w") as f:
+        f.write("Hello World!")
+
+    with ChangeDirContext(tempdir):
+        testtar = await make_tarfile_from_dir("test", testdir)
+        print(testtar)
+
+
+if __name__ == "__main__":
+    run_coroutine(main())

--- a/examples/tarfile_example.py
+++ b/examples/tarfile_example.py
@@ -2,9 +2,11 @@ import os
 import tarfile
 import tempfile
 
+from .utils import ChangeDirContext
+from .utils import run_coroutine
 from async_files import FileIO
-from async_files.fileobj import DEFAULT_CONFIG, FileObj
-from .utils import run_coroutine, ChangeDirContext
+from async_files.fileobj import DEFAULT_CONFIG
+from async_files.fileobj import FileObj
 
 TARBALL_CONFIG = DEFAULT_CONFIG
 TARBALL_CONFIG["strings_async_attrs"].extend(["add", "extract", "extractall"])
@@ -23,8 +25,8 @@ class async_open(FileIO):
 
 
 async def make_tarfile_from_dir(output_filename, source_dir):
-    if not output_filename.endswith('.gz'):
-        output_filename += '.tar.gz'
+    if not output_filename.endswith(".gz"):
+        output_filename += ".tar.gz"
     async with async_open(output_filename, "w:gz") as tar:
         await tar.add(source_dir, arcname=".")
 

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -21,15 +21,15 @@ def get_event_loop():
     except RuntimeError:
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
-    if sys.platform.startswith("win"):
-        if isinstance(loop, asyncio.SelectorEventLoop):
-            loop = asyncio.ProactorEventLoop()
-            asyncio.set_event_loop(loop)
+    if sys.platform.startswith("win") and isinstance(
+        loop, asyncio.SelectorEventLoop
+    ):
+        loop = asyncio.ProactorEventLoop()
+        asyncio.set_event_loop(loop)
     return loop
 
 
 def run_coroutine(coro):
     loop = get_event_loop()
     aws = asyncio.ensure_future(coro)
-    result = loop.run_until_complete(aws)
-    return result
+    return loop.run_until_complete(aws)

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -1,5 +1,18 @@
 import asyncio
+import os
 import sys
+
+
+class ChangeDirContext:
+    def __init__(self, destination_dir):
+        self.current_dir = os.getcwd()
+        self.destination_dir = destination_dir
+
+    def __enter__(self):
+        os.chdir(self.destination_dir)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        os.chdir(self.current_dir)
 
 
 def get_event_loop():

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -22,8 +22,7 @@ def get_event_loop():
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
     if sys.platform.startswith("win") and isinstance(
-        loop, asyncio.SelectorEventLoop
-    ):
+            loop, asyncio.SelectorEventLoop):
         loop = asyncio.ProactorEventLoop()
         asyncio.set_event_loop(loop)
     return loop


### PR DESCRIPTION
`bound_args.arguments` doesn't contain map appropriately if target file open function has `*args` and `**kwargs` as parameters. This can be fixed by using `bound_args.args` and `bound_args.kwargs` instead.

Fixes: issue #24